### PR TITLE
Janadamski/sc 51200/stripehybrid old tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem 'activesupport', '~> 7.0', '>= 7.0.5'
   gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
   gem "rack", ">= 2.0.6"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem 'activesupport', '~> 7.0', '>= 7.0.5'
   gem "coveralls", require: false
   gem "mocha", "~> 0.13.2"
   gem "rack", ">= 2.0.6"

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -369,6 +369,8 @@ module Stripe
         return mth.call(args[0])
       elsif @values.key?(name)
         return @values[name]
+      elsif name.to_s.end_with?("?") && @values.key?(name.to_s[0...-1]&.to_sym)
+        return @values[name.to_s[0...-1]&.to_sym]
       elsif name.to_s.end_with?("?") && @values.key?(name.to_s[0...-1])
         return @values[name.to_s[0...-1]]
       end

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -509,29 +509,6 @@ module Stripe
       end
     end
 
-    # Produces a deep copy of the given object including support for arrays,
-    # hashes, and StripeObjects.
-    private_class_method def self.deep_copy(obj)
-      case obj
-      when Array
-        obj.map { |e| deep_copy(e) }
-      when Hash
-        obj.each_with_object({}) do |(k, v), copy|
-          copy[k] = deep_copy(v)
-          copy
-        end
-      when StripeObject
-        obj.class.construct_from(
-          deep_copy(obj.instance_variable_get(:@values)),
-          obj.instance_variable_get(:@opts).select do |k, _v|
-            Util::OPTS_COPYABLE.include?(k)
-          end
-        )
-      else
-        obj
-      end
-    end
-
     private def dirty_value!(value)
       case value
       when Array

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -509,6 +509,29 @@ module Stripe
       end
     end
 
+    # Produces a deep copy of the given object including support for arrays,
+    # hashes, and StripeObjects.
+    private_class_method def self.deep_copy(obj)
+      case obj
+      when Array
+        obj.map { |e| deep_copy(e) }
+      when Hash
+        obj.each_with_object({}) do |(k, v), copy|
+          copy[k] = deep_copy(v)
+          copy
+        end
+      when StripeObject
+        obj.class.construct_from(
+          deep_copy(obj.instance_variable_get(:@values)),
+          obj.instance_variable_get(:@opts).select do |k, _v|
+            Util::OPTS_COPYABLE.include?(k)
+          end
+        )
+      else
+        obj
+      end
+    end
+
     private def dirty_value!(value)
       case value
       when Array

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -369,6 +369,8 @@ module Stripe
         return mth.call(args[0])
       elsif @values.key?(name)
         return @values[name]
+      elsif name.to_s.end_with?("?") && @values.key?(name.to_s[0...-1])
+        return @values[name.to_s[0...-1]]
       end
 
       begin
@@ -390,7 +392,8 @@ module Stripe
     # rubocop:enable Style/MissingRespondToMissing
 
     protected def respond_to_missing?(symbol, include_private = false)
-      @values && @values.key?(symbol) || super
+      return true if @values&.key?(symbol) || (@values&.key?(symbol.to_s[0...-1].to_sym) && symbol.to_s.end_with?("?"))
+      super
     end
 
     # Re-initializes the object based on a hash of values (usually one that's

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -147,7 +147,6 @@ module Stripe
     #   StripeObject. Defaults to true.
     def update_attributes(values, opts = {}, dirty: true)
       values.each do |k, v|
-        add_accessors([k], values) unless metaclass.method_defined?(k.to_sym)
         @values[k] = Util.convert_to_stripe_object(v, opts)
         dirty_value!(@values[k]) if dirty
         @unsaved_values.add(k)

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -407,9 +407,7 @@ module Stripe
     #   remove accessors.
     protected def initialize_from(values, opts, partial = false)
       @opts = Util.normalize_opts(opts)
-
-      # the `#send` is here so that we can keep this method private
-      @original_values = self.class.send(:deep_copy, values)
+      @original_values = values
 
       removed = partial ? Set.new : Set.new(@values.keys - values.keys)
       added = Set.new(values.keys - @values.keys)
@@ -419,7 +417,6 @@ module Stripe
       # values which don't persist as transient
 
       remove_accessors(removed)
-      add_accessors(added, values)
 
       removed.each do |k|
         @values.delete(k)

--- a/lib/stripe/stripe_object.rb
+++ b/lib/stripe/stripe_object.rb
@@ -514,29 +514,6 @@ module Stripe
       end
     end
 
-    # Produces a deep copy of the given object including support for arrays,
-    # hashes, and StripeObjects.
-    private_class_method def self.deep_copy(obj)
-      case obj
-      when Array
-        obj.map { |e| deep_copy(e) }
-      when Hash
-        obj.each_with_object({}) do |(k, v), copy|
-          copy[k] = deep_copy(v)
-          copy
-        end
-      when StripeObject
-        obj.class.construct_from(
-          deep_copy(obj.instance_variable_get(:@values)),
-          obj.instance_variable_get(:@opts).select do |k, _v|
-            Util::OPTS_COPYABLE.include?(k)
-          end
-        )
-      else
-        obj
-      end
-    end
-
     private def dirty_value!(value)
       case value
       when Array

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -102,13 +102,23 @@ module Stripe
     def self.symbolize_names(object)
       case object
       when Hash
-       object.deep_symbolize_keys!
+        new_hash = {}
+        object.each do |key, value|
+          key = (begin
+                   key.to_sym
+                 rescue StandardError
+                   key
+                 end) || key
+          new_hash[key] = symbolize_names(value)
+        end
+        new_hash
       when Array
         object.map { |value| symbolize_names(value) }
       else
         object
       end
     end
+
 
     # Encodes a hash of parameters in a way that's suitable for use as query
     # parameters in a URI or as form parameters in a request body. This mainly

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -102,7 +102,16 @@ module Stripe
     def self.symbolize_names(object)
       case object
       when Hash
-       object.deep_symbolize_keys!
+        new_hash = {}
+        object.each do |key, value|
+          key = (begin
+                   key.to_sym
+                 rescue StandardError
+                   key
+                 end) || key
+          new_hash[key] = symbolize_names(value)
+        end
+        new_hash
       when Array
         object.map { |value| symbolize_names(value) }
       else

--- a/lib/stripe/util.rb
+++ b/lib/stripe/util.rb
@@ -102,16 +102,7 @@ module Stripe
     def self.symbolize_names(object)
       case object
       when Hash
-        new_hash = {}
-        object.each do |key, value|
-          key = (begin
-                   key.to_sym
-                 rescue StandardError
-                   key
-                 end) || key
-          new_hash[key] = symbolize_names(value)
-        end
-        new_hash
+       object.deep_symbolize_keys!
       when Array
         object.map { |value| symbolize_names(value) }
       else


### PR DESCRIPTION
The changes in this PR are aimed at reducing memo RSS during the import process. 
They consist of two things - not creating copies of objects 
and not initializing all of the accessors when creating stripe objects.
instead, we simply delegate method calls to hash. 

This should be safe for the purpose of ChartMogul imports since we're not modifying those objects and just fetching the data. 